### PR TITLE
Fixing tuning.r to work with single-raster models

### DIFF
--- a/R/tuning.R
+++ b/R/tuning.R
@@ -64,9 +64,9 @@ tuning <- function (occ, env, bg.coords, occ.grp, bg.grp, method, maxent.args,
     ORmin <- double()
 
     for (k in 1:nk) {
-      train.val <- pres[group.data$occ.grp != k, ]
-      test.val <- pres[group.data$occ.grp == k, ]
-      bg.val <- bg[group.data$bg.grp != k, ]
+      train.val <- pres[group.data$occ.grp != k, , drop=FALSE]
+      test.val <- pres[group.data$occ.grp == k, , drop=FALSE]
+      bg.val <- bg[group.data$bg.grp != k, , drop=FALSE]
       x <- rbind(train.val, bg.val)
       p <- c(rep(1, nrow(train.val)), rep(0, nrow(bg.val)))
       mod <- maxent(x, p, args = c(maxent.args[[i]], userArgs), factors = categoricals,


### PR DESCRIPTION
Before this change, ENMevaluate does NOT work when forming a model using a single raster layer. 

NOTE: this is NOT the same issue that arises when a single raster layer is used instead of a raster stack with only one layer in it. That's a different problem. The bug I'm fixing here occurs when env (the input to tuning() ) is a raster stack containing one raster. 

Instead, there's some data.frame subsetting that happens within the tune() function that assumes a 2-dimensional data.frame. Usually that's fine, until you only have one raster layer and therefore the data.frame objects "train.val", "test.val" and "bg.val" each have a single column. When they are subset using [some_logical, ], R( in its infinite wisdom) returns a vector, NOT a data.frame. This is solved by adding "drop=FALSE", which I've done here.