### PR TITLE
Fixed issue: AIC calculation when running in parallel

### DIFF
--- a/R/tuning.R
+++ b/R/tuning.R
@@ -95,7 +95,7 @@ tuning <- function (occ, env, bg.coords, occ.grp, bg.grp, method, algorithm, arg
                                            userArgs, rasterPreds, clamp)
                      }
     }
-    stopCluster(c1)
+    # stopCluster(c1)
   } else {
     out <- list()
     if (progbar == TRUE & !is.function(updateProgress)) {
@@ -193,6 +193,12 @@ tuning <- function (occ, env, bg.coords, occ.grp, bg.grp, method, algorithm, arg
 
   if (rasterPreds==TRUE) {
     names(predictive.maps) <- settings
+    if(parallel) {
+      message("predictions are not available when running in parallel")
+      predictive.maps <- stack()
+      stopCluster(c1)
+    }# because predictive maps won't be available 
+    # when running in parallel, it is better just to remove them from results
   }
 
   results <- ENMevaluation(algorithm = alg, results = res, predictions = predictive.maps,

--- a/R/tuning.R
+++ b/R/tuning.R
@@ -196,6 +196,7 @@ tuning <- function (occ, env, bg.coords, occ.grp, bg.grp, method, algorithm, arg
     if(parallel) {
       message("predictions are not available when running in parallel")
       predictive.maps <- stack()
+      raster::removeTmpFiles(h=0)
       stopCluster(c1)
     }# because predictive maps won't be available 
     # when running in parallel, it is better just to remove them from results


### PR DESCRIPTION
Now temp rasters are kept until all rasterPreds are created and AIC is computed.
However, rasterPreds are erased after parallel runs finish because they are created as temporary files.